### PR TITLE
Fix table loading when no records exist

### DIFF
--- a/EInvoice/Views/Addresses/Index.cshtml
+++ b/EInvoice/Views/Addresses/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Adresler";
 }
 
@@ -148,6 +148,10 @@
             const body = document.querySelector('#addressesTable tbody');
             body.innerHTML = '';
             const rowsToRender = rows || cachedRows;
+            if (!rowsToRender || rowsToRender.length === 0) {
+                body.innerHTML = `<tr><td colspan="4" class="text-center text-muted">Kayıt yok</td></tr>`;
+                return;
+            }
             rowsToRender.forEach(r => {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `

--- a/EInvoice/Views/Currents/Index.cshtml
+++ b/EInvoice/Views/Currents/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
 	ViewData["Title"] = "Cariler";
 }
 
@@ -220,6 +220,10 @@
 			const body = document.querySelector('#currentsTable tbody');
 			body.innerHTML = '';
 			const rowsToRender = rows || (currentFilter === null ? cachedRows : cachedRows.filter(r => r.currentType === Number(currentFilter)));
+			if (!rowsToRender || rowsToRender.length === 0) {
+				body.innerHTML = `<tr><td colspan="6" class="text-center text-muted">Kayıt yok</td></tr>`;
+				return;
+			}
 			rowsToRender.forEach(r => {
 				const tr = document.createElement('tr');
 				tr.dataset.currentType = r.currentType;

--- a/EInvoice/Views/CustomersSuppliers/Index.cshtml
+++ b/EInvoice/Views/CustomersSuppliers/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Müşteri/Tedarikçi";
 }
 
@@ -167,6 +167,10 @@
             const body = document.querySelector('#csTable tbody');
             body.innerHTML = '';
             const rows = getFilteredRows();
+            if (!rows || rows.length === 0) {
+                body.innerHTML = `<tr><td colspan="4" class="text-center text-muted">Kayıt yok</td></tr>`;
+                return;
+            }
             rows.forEach(r => {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `

--- a/EInvoice/Views/Invoices/Index.cshtml
+++ b/EInvoice/Views/Invoices/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Faturalar";
 }
 
@@ -221,6 +221,10 @@
             if (table) { table.destroy(); table = null; }
             const body = document.querySelector('#invTable tbody');
             body.innerHTML = '';
+            if (!cachedInvoices || cachedInvoices.length === 0) {
+                body.innerHTML = `<tr><td colspan="8" class="text-center text-muted">Kayıt yok</td></tr>`;
+                return;
+            }
             cachedInvoices.forEach(r => {
                 const tr = document.createElement('tr');
                 const date = r.date ? new Date(r.date) : null;

--- a/EInvoice/Views/ProductsAndServices/Index.cshtml
+++ b/EInvoice/Views/ProductsAndServices/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Ürünler & Hizmetler";
 }
 
@@ -144,6 +144,10 @@
             if (table) { table.destroy(); table = null; }
             const body = document.querySelector('#pasTable tbody');
             body.innerHTML = '';
+            if (!cachedRows || cachedRows.length === 0) {
+                body.innerHTML = `<tr><td colspan="5" class="text-center text-muted">Kayıt yok</td></tr>`;
+                return;
+            }
             cachedRows.forEach(r => {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `


### PR DESCRIPTION
Add empty state rows and conditional DataTable initialization to fix table rendering issues when the first record is added to an empty table.

The Simple-DataTables plugin was being initialized even when the table had no rows, leading to a malformed appearance when the first record was subsequently added. This change ensures that the table displays a "Kayıt yok" message when empty and the DataTable plugin is only initialized once data is present, allowing for a clean re-render.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c3be89-a8e4-4d56-93ef-ecf3a8e61364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09c3be89-a8e4-4d56-93ef-ecf3a8e61364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

